### PR TITLE
Fix Preferencses bug + naming conventions

### DIFF
--- a/src/components/ProfileCard.jsx
+++ b/src/components/ProfileCard.jsx
@@ -4,11 +4,11 @@ import "../styles/ProfileCard.css";
 const ProfileCard = ({
   name,
   email,
-  picProfile,
-  startTime,
-  endTime,
-  breakTime,
-  SessionLength,
+  pictureUrl,
+  userStudyStartTime,
+  userStudyEndTime,
+  userBreakTime,
+  studySessionTime,
   studyOnHolidays,
   studyOnWeekends,
   onClick,
@@ -26,7 +26,7 @@ const ProfileCard = ({
           <div className="upper-container card-body">
             <div className="image-container d-flex justify-content-center">
               <img
-                src={picProfile}
+                src={pictureUrl}
                 alt="profile Pic"
                 height="100px"
                 width="100px"
@@ -54,7 +54,7 @@ const ProfileCard = ({
                     <h6 className="mb-0 title-in-preferences">Study Start Time:</h6>
                   </Col>
                   <Col xs={6}>
-                    <h6 className="mb-0">{startTime}</h6>
+                    <h6 className="mb-0">{userStudyStartTime}</h6>
                   </Col>
                 </Row>
                 <Row className="mb-2">
@@ -62,7 +62,7 @@ const ProfileCard = ({
                     <h6 className="mb-0 title-in-preferences">Study End Time:</h6>
                   </Col>
                   <Col xs={6}>
-                    <h6 className="mb-0">{endTime}</h6>
+                    <h6 className="mb-0">{userStudyEndTime}</h6>
                   </Col>
                 </Row>
                 <Row className="mb-2">
@@ -70,7 +70,7 @@ const ProfileCard = ({
                     <h6 className="mb-0 title-in-preferences">Break Time Size:</h6>
                   </Col>
                   <Col xs={6}>
-                    <h6 className="mb-0">{breakTime} Minutes</h6>
+                    <h6 className="mb-0">{userBreakTime} Minutes</h6>
                   </Col>
                 </Row>
                 <Row className="mb-2">
@@ -78,7 +78,7 @@ const ProfileCard = ({
                     <h6 className="mb-0 title-in-preferences">Study Session Size:</h6>
                   </Col>
                   <Col xs={6}>
-                    <h6 className="mb-0">{SessionLength} Minutes</h6>
+                    <h6 className="mb-0">{studySessionTime} Minutes</h6>
                   </Col>
                 </Row>
                 <Row className="mb-2">

--- a/src/pages/EditPreferences.jsx
+++ b/src/pages/EditPreferences.jsx
@@ -6,6 +6,7 @@ import api from "../api/axiosBackendConfig";
 import { UserContext } from "../context/UserContext";
 
 function EditPreferences() {
+
   const { subjectID } = useContext(UserContext);
   const [loading, setLoading] = useState(false);
 
@@ -54,8 +55,8 @@ function EditPreferences() {
     userStudyEndTime: oldUserPreferences.userStudyEndTime,
     userBreakTime: oldUserPreferences.userBreakTime,
     studySessionTime: oldUserPreferences.studySessionTime,
-    isStudyOnHolidays: oldUserPreferences.studyOnHolidays ? "on" : "",
-    isStudyOnWeekends: oldUserPreferences.studyOnWeekends ? "on" : "",
+    studyOnHolidays: oldUserPreferences.studyOnHolidays ? "on" : "",
+    studyOnWeekends: oldUserPreferences.studyOnWeekends ? "on" : "",
   });
 
   /**
@@ -73,12 +74,18 @@ function EditPreferences() {
 
     preferences.userBreakTime = parseInt(preferences.userBreakTime);
     preferences.studySessionTime = parseInt(preferences.studySessionTime);
+
+
   };
 
   const handleSubmit = (event) => {
     event.preventDefault();
     setLoading(true);
+    console.log("pref before convert: ");
+    console.log( userPreferences);
     convertUserPreferencesToBackendValues(userPreferences);
+    console.log("pref after convert: ");
+    console.log(userPreferences);
     api
       .post("/profile", userPreferences, { params: { sub: subjectID } })
       .then((response) => {
@@ -157,8 +164,8 @@ function EditPreferences() {
         <Form.Group>
           <Form.Check
             type="checkbox"
-            name="isStudyOnHolyDays"
-            checked={userPreferences.isStudyOnHolidays}
+            name="studyOnHolidays"
+            checked={userPreferences.studyOnHolidays}
             onChange={handleChange}
             label="Study On Holidays"
           />
@@ -166,8 +173,8 @@ function EditPreferences() {
         <Form.Group>
           <Form.Check
             type="checkbox"
-            name="isStudyOnWeekends"
-            checked={userPreferences.isStudyOnWeekends}
+            name="studyOnWeekends"
+            checked={userPreferences.studyOnWeekends}
             onChange={handleChange}
             label="Study On Weekends"
           />

--- a/src/pages/EditPreferences.jsx
+++ b/src/pages/EditPreferences.jsx
@@ -43,6 +43,8 @@ function EditPreferences() {
       2
     )}:${userStudyEndTime.substr(2)}`;
     // Convert other fields as needed
+    console.log("cpyUserPreferences: ");
+    console.log(cpyUserPreferences);
     return cpyUserPreferences;
   };
   oldUserPreferences =
@@ -55,8 +57,8 @@ function EditPreferences() {
     userStudyEndTime: oldUserPreferences.userStudyEndTime,
     userBreakTime: oldUserPreferences.userBreakTime,
     studySessionTime: oldUserPreferences.studySessionTime,
-    studyOnHolidays: oldUserPreferences.studyOnHolidays ? "on" : "",
-    studyOnWeekends: oldUserPreferences.studyOnWeekends ? "on" : "",
+    studyOnHolidays: oldUserPreferences.studyOnHolidays,
+    studyOnWeekends: oldUserPreferences.studyOnWeekends
   });
 
   /**
@@ -75,14 +77,13 @@ function EditPreferences() {
     preferences.userBreakTime = parseInt(preferences.userBreakTime);
     preferences.studySessionTime = parseInt(preferences.studySessionTime);
 
-
   };
 
   const handleSubmit = (event) => {
     event.preventDefault();
     setLoading(true);
     console.log("pref before convert: ");
-    console.log( userPreferences);
+    console.log( userPreferences );
     convertUserPreferencesToBackendValues(userPreferences);
     console.log("pref after convert: ");
     console.log(userPreferences);
@@ -119,6 +120,8 @@ function EditPreferences() {
         [name]: value,
       });
     }
+
+    console.log(userPreferences);
   };
 
   return (

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -17,6 +17,7 @@ import ProfileCard from "../components/ProfileCard";
 import { animated, useSpring } from "react-spring";
 
 function Profile() {
+  
   const convertUserStudyTimeToHours = (userStudyTime) => {
     const hour = Math.floor(userStudyTime / 100);
     if (hour < 10) {
@@ -64,9 +65,11 @@ function Profile() {
         console.log(error);
       }
     };
+
     if (isAuthenticated) {
       getUserData();
     }
+
   }, [isAuthenticated]);
 
   if (!isAuthenticated) {
@@ -91,8 +94,8 @@ function Profile() {
           <ProfileCard
             name={userData.profile.name}
             email={userData.profile.email}
-            picProfile={userData.profile.pictureUrl}
-            startTime={
+            pictureUrl={userData.profile.pictureUrl}
+            userStudyStartTime={
               convertUserStudyTimeToHours(
                 userData.userPreferences.userStudyStartTime
               ).toString() +
@@ -101,7 +104,7 @@ function Profile() {
                 userData.userPreferences.userStudyStartTime
               ).toString()
             }
-            endTime={
+            userStudyEndTime={
               convertUserStudyTimeToHours(
                 userData.userPreferences.userStudyEndTime
               ).toString() +
@@ -110,8 +113,8 @@ function Profile() {
                 userData.userPreferences.userStudyEndTime
               ).toString()
             }
-            breakTime={userData.userPreferences.userBreakTime}
-            SessionLength={userData.userPreferences.studySessionTime}
+            userBreakTime={userData.userPreferences.userBreakTime}
+            studySessionTime={userData.userPreferences.studySessionTime}
             studyOnHolidays={userData.userPreferences.studyOnHolidays}
             studyOnWeekends={userData.userPreferences.studyOnWeekends}
             onClick={handleEditPreferences}


### PR DESCRIPTION
I've fixed a bug in EditPreferences: when the studyOnHolidays / studyOnWeekends is already set to true (already set to true in the backend), and you click "save" while it is still true, there is a 400 BAD REQUEST error.

Also, I've fixed some naming conventions of the Profile, EditPreferences, ProfileCard
