### PR TITLE
Fix generated study plan display

### DIFF
--- a/src/components/Exam.jsx
+++ b/src/components/Exam.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 
-function Exam({ course }) {
+function Exam({ courseName, dateTimeISO}) {
   return (
     <div>
-      <h4>{course.courseName}</h4>
+      <h4>{courseName}</h4>
+      <h6>{dateTimeISO}</h6>
     </div>
   );
 }

--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -46,6 +46,7 @@ const GenerateCalendar = () => {
             },
           }
         );
+        console.log(response.data);
 
         setStudyPlan(response.data.studyPlan);
       } catch (error) {
@@ -200,7 +201,7 @@ const GenerateCalendar = () => {
                         {studyPlan.scannedExams.map((exam) => {
                           return (
                             <li>
-                              <Exam key={exam.course} course={exam.course} />
+                              <Exam key={exam.course} courseName={exam.courseName} dateTimeISO={exam.dateTimeISO} />
                             </li>
                           );
                         })}
@@ -210,7 +211,7 @@ const GenerateCalendar = () => {
                       Start Date Time of Plan: {studyPlan.startDateTimeOfPlan}
                     </div>
                     <div>
-                      End Date Time of Plan: {studyPlan.endDataTimeOfPlan}
+                      End Date Time of Plan: {studyPlan.endDateTimeOfPlan}
                     </div>
                     <div>
                       Total Number of Study Sessions:{" "}

--- a/src/pages/GenerateCalendar.jsx
+++ b/src/pages/GenerateCalendar.jsx
@@ -40,7 +40,6 @@ const GenerateCalendar = () => {
       try {
         const response = await api.get(
           "/study-plan",
-          {},
           {
             params: {
               sub: subjectID,


### PR DESCRIPTION
I've fixed the request to the server, of /study-plan, to pass the quary parameters properly.
Also, I've fixed the generated study plan that is shown after pressing generate, to be shown correctly